### PR TITLE
MongoDB has ObjectId's for the internal _id right?

### DIFF
--- a/src/ch16-mongodb-version/final/pypi_nosql/pypi/services/user_service.py
+++ b/src/ch16-mongodb-version/final/pypi_nosql/pypi/services/user_service.py
@@ -1,3 +1,4 @@
+import bson
 from typing import Optional
 
 from pypi import DbSession
@@ -43,7 +44,7 @@ def login_user(email: str, password: str) -> Optional[User]:
     return user
 
 
-def find_user_by_id(user_id: int) -> Optional[User]:
+def find_user_by_id(user_id: bson.ObjectId) -> Optional[User]:
     return User.objects(id=user_id).first()
 
 


### PR DESCRIPTION
Shouldn't this type hint be an ObjectId rather  than the current int?